### PR TITLE
Add a regression test for std::call_once crashing

### DIFF
--- a/toolchain/meson/tests/call_once.cpp
+++ b/toolchain/meson/tests/call_once.cpp
@@ -1,0 +1,13 @@
+// std::call_once from libstdc++ always segfaults on Clang 12
+// https://github.com/msys2/MINGW-packages/issues/8706
+
+#include <iostream>
+#include <mutex>
+
+int main()
+{
+    std::once_flag flag;
+    std::call_once(flag, []{std::cout << "Once!\n";});
+
+    return 0;
+}

--- a/toolchain/meson/tests/meson.build
+++ b/toolchain/meson/tests/meson.build
@@ -14,3 +14,5 @@ test('pow', executable('pow', 'pow.c', c_args: ['-fno-builtin', '-fno-strict-ali
 windres_res = import('windows').compile_resources('windres.rc')
 windres = executable('windres', 'windres.c', windres_res)
 test('windres', windres)
+
+test('call_once', executable('call_once', 'call_once.cpp'))


### PR DESCRIPTION
Example taken from https://github.com/msys2/MINGW-packages/issues/8706