### PR TITLE
CI: split out the gcc+clang env combo

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,9 +16,9 @@ jobs:
           { msystem: MINGW64, prefix:  mingw-w64-x86_64, cc: gcc, cxx: g++, fc: gfortran },
           { msystem: MINGW32, prefix:  mingw-w64-i686, cc: gcc, cxx: g++, fc: gfortran },
           { msystem: UCRT64,  prefix:  mingw-w64-ucrt-x86_64, cc: gcc, cxx: g++, fc: gfortran },
-          { msystem: UCRT64,  prefix:  mingw-w64-ucrt-x86_64, cc: clang, cxx: clang++, fc: flang-new },
+          { msystem: UCRT64,  prefix:  mingw-w64-ucrt-x86_64, cc: clang, cxx: clang++, fc: flang },
           { msystem: CLANG32, prefix:  mingw-w64-clang-i686, cc: clang, cxx: clang++ },
-          { msystem: CLANG64, prefix:  mingw-w64-clang-x86_64, cc: clang, cxx: clang++, fc: flang-new },
+          { msystem: CLANG64, prefix:  mingw-w64-clang-x86_64, cc: clang, cxx: clang++, fc: flang },
           { msystem: MSYS, cc: gcc, cxx: g++, fc: gfortran },
         ]
 
@@ -32,7 +32,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - uses: msys2/setup-msys2@v2
-        if: ${{ matrix.msystem != 'MSYS' }}
+        if: ${{ matrix.msystem != 'MSYS' && (matrix.msystem != 'UCRT64' || matrix.cc != 'clang') }}
         with:
           msystem: ${{ matrix.msystem }}
           update: true
@@ -41,11 +41,30 @@ jobs:
             ${{ matrix.prefix }}-ninja
             ${{ matrix.prefix }}-cmake
             ${{ matrix.prefix }}-make
-            ${{ matrix.prefix }}-${{ matrix.cc != 'gcc' && 'openmp' || 'ninja'}}
-            ${{ matrix.prefix }}-${{ matrix.cc != 'gcc' && 'lld' || 'ninja'}}
-            ${{ matrix.prefix }}-${{ matrix.cc != 'gcc' && 'libc++' || 'ninja'}}
-            ${{ matrix.prefix }}-${{ matrix.fc == 'gfortran' && 'gcc-fortran' || 'ninja'}}
-            ${{ matrix.prefix }}-${{ matrix.fc == 'flang-new' && 'flang' || 'ninja'}}
+            ${{ matrix.prefix }}-omp
+            ${{ matrix.prefix }}-fc
+            ${{ matrix.prefix }}-${{ matrix.cc }}
+            ${{ matrix.prefix }}-rust
+            ${{ matrix.prefix }}-python
+            ${{ matrix.prefix }}-python-setuptools
+            ${{ matrix.prefix }}-autotools
+            ${{ matrix.prefix }}-go
+            make
+
+      - uses: msys2/setup-msys2@v2
+        if: ${{ matrix.msystem == 'UCRT64' && matrix.cc == 'clang' }}
+        with:
+          msystem: ${{ matrix.msystem }}
+          update: true
+          install: >-
+            ${{ matrix.prefix }}-meson
+            ${{ matrix.prefix }}-ninja
+            ${{ matrix.prefix }}-cmake
+            ${{ matrix.prefix }}-make
+            ${{ matrix.prefix }}-openmp
+            ${{ matrix.prefix }}-lld
+            ${{ matrix.prefix }}-libc++
+            ${{ matrix.prefix }}-flang
             ${{ matrix.prefix }}-${{ matrix.cc }}
             ${{ matrix.prefix }}-rust
             ${{ matrix.prefix }}-python


### PR DESCRIPTION
This way we can use the virtual packages like omp/fc and install all the "clang in ucrt64" stuff separately.

Also move from flang-new to flang as that package now provides that binary too.