### PR TITLE
Start some path conversion integration tests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -73,6 +73,7 @@ jobs:
             autotools
             ruby
             perl
+            mingw-w64-cross-gcc
 
       - name: Add staging repo
         shell: msys2 {0}

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
-.PHONY: toolchain rust python cmake autotools golang fortran ruby perl
+.PHONY: toolchain rust python cmake autotools golang fortran ruby perl runtime
 
-all: toolchain rust python cmake autotools golang fortran ruby perl
+all: toolchain rust python cmake autotools golang fortran ruby perl runtime
 
 toolchain:
 	(cd toolchain && ./test.sh)
@@ -28,3 +28,6 @@ ruby:
 
 perl:
 	(cd perl && ./test.sh)
+
+runtime:
+	(cd runtime && ./test.sh)

--- a/runtime/echo.c
+++ b/runtime/echo.c
@@ -1,0 +1,100 @@
+#include <stdio.h>
+#include <fcntl.h>
+#include <stdlib.h>
+#include <stringapiset.h>
+#include <processenv.h>
+#include <assert.h>
+
+/**
+ * Takes a zero terminated wide string.
+ *
+ * Returns a malloced utf-8 encoded, null terminated string, or NULL on error.
+ */
+static char *encodeUtf8(const wchar_t *wstr)
+{
+    int nbytes = 0;
+
+    nbytes = WideCharToMultiByte(
+        CP_UTF8, WC_ERR_INVALID_CHARS,
+        wstr, -1, NULL, 0, NULL, NULL);
+    if (nbytes == 0)
+    {
+        return NULL;
+    }
+
+    char *str = malloc(nbytes);
+    if (str == NULL)
+    {
+        return NULL;
+    }
+
+    if (WideCharToMultiByte(
+            CP_UTF8, WC_ERR_INVALID_CHARS,
+            wstr, -1, str, nbytes, NULL, NULL) == 0)
+    {
+        free(str);
+        return NULL;
+    }
+
+    return str;
+}
+
+/**
+ * Prints a zero terminated list of process environment variables as utf-8. The
+ * first item is the number of the following list items as a string.
+ */
+static void printEnvVars()
+{
+    _setmode(1, _O_BINARY);
+
+    LPWCH vars = GetEnvironmentStringsW();
+    LPWCH countVars = vars;
+    size_t count = 0;
+
+    while (*countVars)
+    {
+        count++;
+        countVars += wcslen(countVars) + 1;
+    }
+    printf("%d%c", count, '\0');
+
+    while (*vars)
+    {
+        char *value = encodeUtf8(vars);
+        assert(value != NULL);
+        printf("%s%c", value, '\0');
+        free(value);
+        vars += wcslen(vars) + 1;
+    }
+}
+
+/**
+ * Prints a zero terminated list of process arguments as utf-8. The first item
+ * is the number of the following list items as a string.
+ */
+static void printArgs(int argc, wchar_t **argv)
+{
+    _setmode(1, _O_BINARY);
+
+    printf("%d%c", argc, '\0');
+    for (int i = 0; i < argc; i++)
+    {
+        char *value = encodeUtf8(argv[i]);
+        assert(value != NULL);
+        printf("%s%c", value, '\0');
+        free(value);
+    }
+}
+
+/**
+ * This tool prints all process arguments and environment variables in a format
+ * parsable by other programs, including Unicode support.
+ *
+ * This can be used to test path and env var conversion in cygwin for example.
+ */
+int wmain(int argc, wchar_t **argv)
+{
+    printArgs(argc, argv);
+    printEnvVars();
+    return 0;
+}

--- a/runtime/test.py
+++ b/runtime/test.py
@@ -1,0 +1,50 @@
+import subprocess
+import os
+import sys
+import unittest
+from typing import Tuple, List, Dict
+
+
+DIR = os.path.dirname(os.path.realpath(__file__))
+
+
+def parse_echo(args: List[str]=[], env: Dict[str, str]=os.environ) -> Tuple[List[str], Dict[str, str]]:
+    """Returns the arguments and the environment the called process received"""
+
+    data = subprocess.check_output([os.path.join(DIR, 'echo.exe')] + args, env=env)
+    parts = data.split(b'\x00')
+    num_args = int(parts[0].decode())
+    args_bytes = parts[1:1 + num_args]
+    args = [a.decode() for a in args_bytes]
+    num_env_vars = int(parts[1 + num_args].decode())
+    env_vars_bytes = parts[2 + num_args:2 + num_args + num_env_vars]
+    env_vars = dict(e.decode().split('=', 1) for e in env_vars_bytes)
+    return (args[1:], env_vars)
+
+
+def cygpath(mode: str, path: str) -> str:
+    data = subprocess.check_output(['cygpath', mode, path], text=True)
+    return data.splitlines()[0]
+
+
+class Tests(unittest.TestCase):
+
+    def test_path_root(self):
+        root = cygpath('-m', '/')
+        args = parse_echo(['/'])[0]
+        self.assertEqual(root, args[0])
+
+    def test_env_root(self):
+        root = cygpath('-m', '/')
+        parsed = parse_echo([], {'FOO': '/'})[1]['FOO']
+        self.assertEqual(root, parsed)
+
+
+def suite():
+    return unittest.TestLoader().loadTestsFromName(__name__)
+
+
+if __name__ == '__main__':
+    # We depend on this being cygwin Python
+    assert sys.platform == 'cygwin'
+    unittest.main(defaultTest='suite')

--- a/runtime/test.sh
+++ b/runtime/test.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+set -e
+
+if [[ "$MSYSTEM" != "MSYS" ]]; then
+    echo "skipped not on $MSYSTEM"
+    exit 0;
+fi
+
+/opt/bin/x86_64-w64-mingw32-gcc -municode echo.c -o echo.exe
+
+python test.py


### PR DESCRIPTION
This builds a non-cygwin binary that prints all arguments and env vars and a Python test script which uses it to test the cygwin path conversion.