### PR TITLE
runtime: add tests for pathlists with spaces

### DIFF
--- a/runtime/path_convert/src/main.cpp
+++ b/runtime/path_convert/src/main.cpp
@@ -192,6 +192,10 @@ static const test_data datas[] = {
     ,{"/64/shlib/libgcc_s.a.tmp", "" MSYSROOT2 "/64/shlib/libgcc_s.a.tmp", false}
     ,{"-DVERSION_SOURCES=VERSION;C:/repo/mingw-w64-innoextract/src/innoextract-1.5/VERSION;LICENSE;C:/repo/mingw-w64-innoextract/src/innoextract-1.5/LICENSE", "-DVERSION_SOURCES=VERSION;C:/repo/mingw-w64-innoextract/src/innoextract-1.5/VERSION;LICENSE;C:/repo/mingw-w64-innoextract/src/innoextract-1.5/LICENSE", false}
     ,{"'-DVERSION_SOURCES=VERSION;C:/repo/mingw-w64-innoextract/src/innoextract-1.5/VERSION;LICENSE;C:/repo/mingw-w64-innoextract/src/innoextract-1.5/LICENSE'", "'-DVERSION_SOURCES=VERSION;C:/repo/mingw-w64-innoextract/src/innoextract-1.5/VERSION;LICENSE;C:/repo/mingw-w64-innoextract/src/innoextract-1.5/LICENSE'", false}
+    // some spaces in unix paths: https://github.com/git-for-windows/msys2-runtime/commit/0b2d287629
+    ,{"/foo bar", MSYSROOT2 "/foo bar", false}
+    ,{"/foo bar:/baz quux", MSYSROOT "\\foo bar;" MSYSROOT "\\baz quux", false}
+    ,{"/trash directory.t0123-blub:/", MSYSROOT "\\trash directory.t0123-blub;" MSYSROOT "\\", false}
     ,{0, 0, false}
 };
 

--- a/runtime/path_convert/src/path_conv.cpp
+++ b/runtime/path_convert/src/path_conv.cpp
@@ -58,7 +58,7 @@ void ppl_convert(const char** from, const char* to, char** dst, const char* dste
 
 
 void find_end_of_posix_list(const char** to, int* in_string) {
-    for (; **to != '\0' && (in_string ? (**to != *in_string) : **to != ' '); ++*to) {
+    for (; **to != '\0' && (!in_string || **to != *in_string); ++*to) {
     }
 
     if (**to == *in_string) {
@@ -157,12 +157,6 @@ const char* convert(char *dst, size_t dstlen, const char *src) {
                 in_string = *srcit;
             }
             continue;
-        }
-
-        if (isspace(*srcit)) {
-            //sub_convert(&srcbeg, &srcit, &dstit, dstend, &in_string);
-            //srcbeg = srcit + 1;
-            break;
         }
     }
 

--- a/runtime/path_convert_integration/test.py
+++ b/runtime/path_convert_integration/test.py
@@ -39,6 +39,16 @@ class Tests(unittest.TestCase):
         parsed = parse_echo([], {'FOO': '/'})[1]['FOO']
         self.assertEqual(root, parsed)
 
+    def test_with_spaces(self):
+        # https://github.com/git-for-windows/msys2-runtime/commit/0b2d287629
+        mroot = cygpath('-m', '/')
+        parsed = parse_echo(['/foo bar'], {})[0][0]
+        self.assertEqual(parsed, mroot + "foo bar")
+
+        wroot = cygpath('-w', '/')
+        parsed = parse_echo(['/foo bar:/baz quux'], {})[0][0]
+        self.assertEqual(parsed, wroot + "foo bar;" + wroot + "baz quux")
+
 
 def suite():
     return unittest.TestLoader().loadTestsFromName(__name__)


### PR DESCRIPTION
Adjust the tests for https://github.com/msys2/msys2-runtime/pull/143

Applies the changes to the embedded path code here and also
adds integration tests which tests the real runtime.