### PR TITLE
toolchain: add a test for the binutils backport re undecorated symbols in import libs

### DIFF
--- a/toolchain/meson/tests/def-undec-stdcall/meson.build
+++ b/toolchain/meson/tests/def-undec-stdcall/meson.build
@@ -1,0 +1,15 @@
+# https://github.com/msys2/MINGW-packages/pull/17163
+# https://sourceforge.net/p/mingw-w64/mailman/message/37839853/
+# https://sourceware.org/bugzilla/show_bug.cgi?id=30421
+# In case the exported symbols are forced undecorated via a .def file
+# then binutils also wrongly added them undecortaed to the import library.
+
+lib = shared_library('my-shared-lib',
+                     'my-shared-lib.c',
+                     vs_module_defs: 'my-shared-lib.def')
+
+exec = executable('my-executable',
+                  'my-executable.c',
+                  link_with: [lib])
+
+test('def_undec_stdcall', exec)

--- a/toolchain/meson/tests/def-undec-stdcall/my-executable.c
+++ b/toolchain/meson/tests/def-undec-stdcall/my-executable.c
@@ -1,0 +1,15 @@
+#include <stdlib.h>
+#include <stdio.h>
+
+int __stdcall add_numbers(int, int);
+
+int main(int argc, char **argv)
+{
+  (void) argc;
+  (void) argv;
+
+  if (add_numbers (5, 5) == 10) {
+    return 0;
+  }
+  return 1;
+}

--- a/toolchain/meson/tests/def-undec-stdcall/my-shared-lib.c
+++ b/toolchain/meson/tests/def-undec-stdcall/my-shared-lib.c
@@ -1,0 +1,13 @@
+#include <stdlib.h>
+
+int __stdcall
+add_numbers(int a, int b)
+{
+  return a + b;
+}
+
+int __stdcall
+mul_numbers(int a, int b)
+{
+  return a * b;
+}

--- a/toolchain/meson/tests/def-undec-stdcall/my-shared-lib.def
+++ b/toolchain/meson/tests/def-undec-stdcall/my-shared-lib.def
@@ -1,0 +1,2 @@
+EXPORTS
+   add_numbers

--- a/toolchain/meson/tests/meson.build
+++ b/toolchain/meson/tests/meson.build
@@ -51,3 +51,5 @@ if compiler.get_id() == 'clang' and compiler.get_linker_id() == 'ld.lld'
     test('guard_cf_nochecks-invalid_icall', guard_cf_nochecks, args : ['invalid_icall'])
     test('guard_cf_nochecks-invalid_icall_nocf', guard_cf_nochecks, args : ['invalid_icall_nocf'])
 endif
+
+subdir('def-undec-stdcall')


### PR DESCRIPTION
See https://github.com/msys2/MINGW-packages/pull/17163