### PR TITLE
Add some mingw cross build tests

### DIFF
--- a/toolchain/meson/i686-w64-mingw32.txt
+++ b/toolchain/meson/i686-w64-mingw32.txt
@@ -1,0 +1,15 @@
+[binaries]
+c = 'i686-w64-mingw32-gcc'
+cpp = 'i686-w64-mingw32-g++'
+ar = 'i686-w64-mingw32-ar'
+strip = 'i686-w64-mingw32-strip'
+windres = 'i686-w64-mingw32-windres'
+
+[host_machine]
+system = 'windows'
+cpu_family = 'x86'
+cpu = 'i686'
+endian = 'little'
+
+[properties]
+needs_exe_wrapper = false

--- a/toolchain/meson/meson_options.txt
+++ b/toolchain/meson/meson_options.txt
@@ -1,0 +1,1 @@
+option('cross', type : 'boolean', value : false)

--- a/toolchain/meson/tests/meson.build
+++ b/toolchain/meson/tests/meson.build
@@ -3,7 +3,9 @@ test('snprintf_redef', executable('snprintf_redef', 'snprintf_redef.c'))
 test('quick_exit', executable('quick_exit', 'quick_exit.cpp'))
 test('exception_handling', executable('exception_handling', 'exception_handling.cpp'))
 test('printf_format', executable('printf_format', 'printf_format.c'))
-test('pch', executable('pch', 'pch.cpp', cpp_pch : 'pch/pch.hpp'))
+if not get_option('cross')
+    test('pch', executable('pch', 'pch.cpp', cpp_pch : 'pch/pch.hpp'))
+endif
 
 openmp = dependency('openmp')
 env = environment()
@@ -15,8 +17,9 @@ windres_res = import('windows').compile_resources('windres.rc')
 windres = executable('windres', 'windres.c', windres_res)
 test('windres', windres)
 
-test('call_once', executable('call_once', 'call_once.cpp'))
-
+if not get_option('cross')
+    test('call_once', executable('call_once', 'call_once.cpp'))
+endif
 test('undef_memrchr', executable('undef_memrchr', 'undef_memrchr.c', c_args: ['-O3']))
 
 test('stpcpy_fortify', executable('stpcpy_fortify', 'stpcpy_fortify.c', c_args: ['-O3', '-D_FORTIFY_SOURCE=2']))
@@ -52,4 +55,6 @@ if compiler.get_id() == 'clang' and compiler.get_linker_id() == 'ld.lld'
     test('guard_cf_nochecks-invalid_icall_nocf', guard_cf_nochecks, args : ['invalid_icall_nocf'])
 endif
 
-subdir('def-undec-stdcall')
+if not get_option('cross')
+    subdir('def-undec-stdcall')
+endif

--- a/toolchain/meson/x86_64-w64-mingw32.txt
+++ b/toolchain/meson/x86_64-w64-mingw32.txt
@@ -1,0 +1,15 @@
+[binaries]
+c = 'x86_64-w64-mingw32-gcc'
+cpp = 'x86_64-w64-mingw32-g++'
+ar = 'x86_64-w64-mingw32-ar'
+strip = 'x86_64-w64-mingw32-strip'
+windres = 'x86_64-w64-mingw32-windres'
+
+[host_machine]
+system = 'windows'
+cpu_family = 'x86_64'
+cpu = 'x86_64'
+endian = 'little'
+
+[properties]
+needs_exe_wrapper = false

--- a/toolchain/test.sh
+++ b/toolchain/test.sh
@@ -3,10 +3,24 @@
 set -e
 
 cd meson
-meson _build --werror
+meson setup _build --werror
 meson compile -C _build
 meson test -C _build
 cd ..
+
+if [[ "$MSYSTEM" == "MSYS" ]]; then
+    cd meson
+    meson setup -Dcross=true --cross-file i686-w64-mingw32.txt _build_cross_32 --werror
+    meson compile -C _build
+    meson test -C _build
+    cd ..
+
+    cd meson
+    meson setup -Dcross=true --cross-file x86_64-w64-mingw32.txt _build_cross_64 --werror
+    meson compile -C _build
+    meson test -C _build
+    cd ..
+fi
 
 cd custom
 ./test.sh


### PR DESCRIPTION
Builds the toolchain tests under cygwin using the cross gcc compilers for both i686 and x86_64.

Skip some tests which are broken (likely because of the too old gcc there)

Fixes #42