### PR TITLE
Skip fortran tests for ucrt64+flang

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,7 +16,7 @@ jobs:
           { msystem: MINGW64, prefix:  mingw-w64-x86_64, cc: gcc, cxx: g++, fc: gfortran },
           { msystem: MINGW32, prefix:  mingw-w64-i686, cc: gcc, cxx: g++, fc: gfortran },
           { msystem: UCRT64,  prefix:  mingw-w64-ucrt-x86_64, cc: gcc, cxx: g++, fc: gfortran },
-          { msystem: UCRT64,  prefix:  mingw-w64-ucrt-x86_64, cc: clang, cxx: clang++, fc: flang },
+          { msystem: UCRT64,  prefix:  mingw-w64-ucrt-x86_64, cc: clang, cxx: clang++, fc: '' },
           { msystem: CLANG32, prefix:  mingw-w64-clang-i686, cc: clang, cxx: clang++ },
           { msystem: CLANG64, prefix:  mingw-w64-clang-x86_64, cc: clang, cxx: clang++, fc: flang },
           { msystem: MSYS, cc: gcc, cxx: g++, fc: gfortran },

--- a/fortran/test.sh
+++ b/fortran/test.sh
@@ -7,6 +7,11 @@ if [[ "$MSYSTEM" == "CLANG32" || "$MSYSTEM" == "MSYS" ]]; then
     exit 0;
 fi
 
+if [[ "$MSYSTEM" == "UCRT64" && "$CC" == "clang" ]]; then
+    echo "skipped on $MSYSTEM with clang"
+    exit 0;
+fi
+
 FC="${FC:-gfortran}"
 
 "$FC" hello.f90 -o hello.exe


### PR DESCRIPTION
We no longer have a working flang in the gcc envs since https://github.com/msys2/MINGW-packages/pull/18589 so stop testing it