### PR TITLE
toolchain: fix cross compile tests

### DIFF
--- a/toolchain/test.sh
+++ b/toolchain/test.sh
@@ -11,14 +11,14 @@ cd ..
 if [[ "$MSYSTEM" == "MSYS" ]]; then
     cd meson
     meson setup --cross-file i686-w64-mingw32.txt _build_cross_32 --werror
-    meson compile -C _build
-    meson test -C _build
+    meson compile -C _build_cross_32
+    meson test -C _build_cross_32
     cd ..
 
     cd meson
     meson setup --cross-file x86_64-w64-mingw32.txt _build_cross_64 --werror
-    meson compile -C _build
-    meson test -C _build
+    meson compile -C _build_cross_64
+    meson test -C _build_cross_64
     cd ..
 fi
 


### PR DESCRIPTION
they were using the wrong build dir :(