### PR TITLE
pathconv: don't skip arguments with quotes

### DIFF
--- a/runtime/path_convert/src/main.cpp
+++ b/runtime/path_convert/src/main.cpp
@@ -199,8 +199,9 @@ static const test_data datas[] = {
     // some spaces in unix paths: https://github.com/git-for-windows/msys2-runtime/commit/0b2d287629
     ,{"/foo bar", MSYSROOT2 "/foo bar", false}
     ,{"/foo bar:/baz quux", MSYSROOT "\\foo bar;" MSYSROOT "\\baz quux", false}
-    ,{"/trash directory.t0123-blub:/", MSYSROOT "\\trash directory.t0123-blub;" MSYSROOT "\\", false}
-    ,
+    ,{"/trash directory.t0123-blub:/", MSYSROOT "\\trash directory.t0123-blub;" MSYSROOT "\\", false},
+    // https://github.com/msys2/msys2-runtime/issues/190
+    {"\"/foo\"", "\"" MSYSROOT2 "/foo\"", false},
     // https://github.com/msys2/msys2-runtime/commit/7f5ce2cb55bf18020a68f88c2861ea862feb8178
     {"~/foo", "~/foo", false},
     {"~/.gitconfig", "~/.gitconfig", false},
@@ -210,7 +211,6 @@ static const test_data datas[] = {
     // https://github.com/msys2/msys2-runtime/commit/cfc7696e0825563fb4245377ab70887cde160cd1
     {"`/foo", "`/foo", false},
     {"'/foo", "'/foo", false},
-    {"\"/foo", "\"/foo", false},
     {"*/foo", "*/foo", false},
     {"?/foo", "?/foo", false},
     {"[/foo", "[/foo", false},

--- a/runtime/path_convert/src/path_conv.cpp
+++ b/runtime/path_convert/src/path_conv.cpp
@@ -399,7 +399,6 @@ skip_p2w:
         switch (*it) {
         case '`':
         case '\'':
-        case '"':
         case '*':
         case '?':
         case '[':

--- a/runtime/path_convert_integration/test.py
+++ b/runtime/path_convert_integration/test.py
@@ -69,6 +69,12 @@ class Tests(unittest.TestCase):
         self.assertEqual(args, ['/usr', 'adad'])
         self.assertEqual(envs['FOO'], '/bla')
 
+    def test_pass_string_to_preprocessor(self):
+        # https://github.com/msys2/msys2-runtime/issues/190
+        parsed = parse_echo(['-DPREFIX="/ucrt64"'], {})[0][0]
+        mroot = cygpath('-m', '/')
+        self.assertEqual(parsed, f'-DPREFIX="{mroot}ucrt64"')
+
 
 def suite():
     return unittest.TestLoader().loadTestsFromName(__name__)


### PR DESCRIPTION
it is used to pass strings/paths to the preprocessor and breaks for example the CPython build