### PR TITLE
path_conv: backport forgotten part of msys2/msys2-runtime#179

### DIFF
--- a/runtime/path_convert/src/path_conv.cpp
+++ b/runtime/path_convert/src/path_conv.cpp
@@ -551,7 +551,7 @@ skip_p2w:
                         goto skip_p2w;
                     return POSIX_PATH_LIST;
                 }
-            } else if (memchr(it2, '=', end - it) == NULL) {
+            } else if (memchr(it2, '=', end - it2) == NULL) {
                 return SIMPLE_WINDOWS_PATH;
             }
         } else if (ch != '.') {


### PR DESCRIPTION
In https://github.com/msys2/msys2-runtime/pull/179 ("Fix out-of-bound access in path conversion"), _two_ instances were fixed where `it` was used when `it2` should have been used instead.

In 3a20d2f (Sync path_conv.pp with msys2-runtime, 2023-12-22), only one of those fixes was applied. Let's apply the other one, too.