### PR TITLE
Enable check_libraries_reproducible test for Clang envs

### DIFF
--- a/toolchain/custom/test-reproducible.sh
+++ b/toolchain/custom/test-reproducible.sh
@@ -21,9 +21,6 @@ check_libraries_reproducible() {
 if [[ "$MSYSTEM" == "MSYS" ]]; then
     echo "skipped on $MSYSTEM"
     exit 0;
-elif [[ "$MSYSTEM" == "CLANG32" || "$MSYSTEM" == "CLANG64" ]]; then
-    echo "FIXME: skipped on $MSYSTEM"
-    exit 0;
 fi
 
 check_libraries_reproducible


### PR DESCRIPTION
Fixed in https://github.com/llvm/llvm-project/pull/81326