### PR TITLE
Fix pathconv issues related to relative paths in path lists

### DIFF
--- a/runtime/path_convert/src/main.cpp
+++ b/runtime/path_convert/src/main.cpp
@@ -177,10 +177,11 @@ static const test_data datas[] = {
     ,{"@/foo/bar@", "@" MSYSROOT2 "/foo/bar@", false}
     ,{"'@/foo/bar'", "'@/foo/bar'", false}
     ,{"///foo/bar", "//foo/bar", false}
-    ,{".:./", ".:./", false}
-    ,{"..:./", "..:./", false}
-    ,{"../:./", "../:./", false}
-    ,{"../aa/:./", "../aa/:./", false}
+    ,{".:./", ".;.\\", false}
+    ,{"..:./", "..;.\\", false}
+    ,{"../:./", "..\\;.\\", false}
+    ,{"../:./", "..\\;.\\", false}
+    ,{"../aa/:./", "..\\aa\\;.\\", false}
     ,{"../", "../", false}
     ,{"/foo/bar/", "" MSYSROOT2 "/foo/bar/", false}
     ,{"-MExtUtils::ParseXS=process_file", "-MExtUtils::ParseXS=process_file", false}
@@ -236,6 +237,12 @@ static const test_data datas[] = {
     {".:/tmp/", ".;" MSYSROOT "\\tmp\\", false},
     {"..:/tmp/", "..;" MSYSROOT "\\tmp\\", false},
     {".:..:/tmp/", ".;..;" MSYSROOT "\\tmp\\", false},
+    {"/this:./there", MSYSROOT "\\this;.\\there", false},
+    {"..:.:./this:/there", "..;.;.\\this;" MSYSROOT "\\there", false},
+    {"--dir=/this:./there", "--dir=" MSYSROOT "\\this;.\\there", false},
+    {"--dir=./this:./there", "--dir=.\\this;.\\there", false},
+    {"WEBINPUTS=.:../../../texk/web2c", "WEBINPUTS=.;..\\..\\..\\texk\\web2c", false},
+    {".:../../../texk/web2c", ".;..\\..\\..\\texk\\web2c", false},
     {"/:/tmp/", MSYSROOT "\\;" MSYSROOT "\\tmp\\", false},
     {0, 0, false}
 };

--- a/runtime/path_convert/src/main.cpp
+++ b/runtime/path_convert/src/main.cpp
@@ -287,6 +287,7 @@ int main() {
     int passed = 0;
     int total = 0;
     for ( const test_data *it = &datas[0]; it && it->src; ++it ) {
+        printf("---\n");
         total += 1;
         const char *path = it->src;
         const size_t blen = strlen(it->dst)*2 + 10;

--- a/runtime/path_convert/src/main.cpp
+++ b/runtime/path_convert/src/main.cpp
@@ -21,7 +21,7 @@ typedef struct test_data_t {
 #error "Need to define both MSYSROOT and MSYSROOT2, or neither"
 #endif
 #else
-#ifdef MSYSROOT
+#ifdef MSYSROOT2
 #error "Need to define both MSYSROOT and MSYSROOT2, or neither"
 #endif
 #if defined(__MSYS__) && defined(__LP64__)

--- a/runtime/path_convert/src/path_conv.cpp
+++ b/runtime/path_convert/src/path_conv.cpp
@@ -391,15 +391,15 @@ skip_p2w:
 
     /*
      * Discern between Git's `<rev>:<path>`, SCP's `<host>:<path>` pattern
-     * (which is not a path list but may naïvely look like one) on the one
+     * (which is not a path list but may naively look like one) on the one
      * hand, and path lists starting with `/<path>`, `./<path>` or `../<path>`
      * on the other hand.
      */
     bool potential_path_list = *it == '/' ||
-	    (*it == '.' &&
-		(it[1] == ':' || it[1] == '/' ||
-		 (it[1] == '.' &&
-			(it[2] == ':' || it[2] == '/'))));
+        (*it == '.' &&
+         (it + 1 == end || it[1] == '\0' || it[1] == ':' || it[1] == '/' ||
+          (it[1] == '.' &&
+           (it + 2 == end || it[2] == '\0' || it[2] == ':' || it[2] == '/'))));
 
     /*
      * Determine if assignment to an environment variable takes place (and


### PR DESCRIPTION
I'm not sure if I got it right, but it seems that the fix proposed in https://github.com/msys2/msys2-runtime/pull/212 doesn't handle values (e.g. potential path lists) being assigned to a process local environment variable, like in a call `VARNAME=.:../foo ./my-script.sh`.

This tries to add an additional check to cover this case.

@dscho What's your opinion on that?