### PR TITLE
toolchain: wildcard is now disabled by default

### DIFF
--- a/toolchain/meson/tests/wildcard.c
+++ b/toolchain/meson/tests/wildcard.c
@@ -4,7 +4,7 @@
     #undef DO_WILDCARD
     #define DO_WILDCARD 0
 #else
-    #define DO_WILDCARD_DEFAULT 1
+    #define DO_WILDCARD_DEFAULT 0
     #ifndef DO_WILDCARD
         #define DO_WILDCARD DO_WILDCARD_DEFAULT
     #else


### PR DESCRIPTION
See https://github.com/msys2/MINGW-packages/pull/22263