### PR TITLE
Fix `msys2-tests-*-clang` breakage

### DIFF
--- a/gha-matrix-gen/action.yml
+++ b/gha-matrix-gen/action.yml
@@ -71,7 +71,7 @@ runs:
               if entry['cc'] == 'gcc':
                 entry['packages'].append(f"{ entry['prefix'] }-gcc-ada")
               else:
-                entry['packages'].append(f"{ entry['prefix'] }-openmp")
+                entry['packages'].append(f"{ entry['prefix'] }-llvm-openmp")
           else:
             entry['packages'] = [
               'meson',


### PR DESCRIPTION
As noticed in https://github.com/msys2/msys2-runtime/pull/331, the
`msys2-tests-*-clang` jobs are currently broken. The [symptom](https://github.com/msys2/msys2-runtime/actions/runs/23570683914/job/68660991486?pr=331#step:2:314) is:

```
  ▼ Installing additional packages through pacman...
    C:\Windows\system32\cmd.exe /D /S /C C:\a\_temp\setup-msys2\msys2.cmd
      -c "'pacman' '--noconfirm' '-S' '--needed' '--overwrite' '*'
      'mingw-w64-clang-aarch64-meson' 'mingw-w64-clang-aarch64-ninja'
      'mingw-w64-clang-aarch64-cmake' 'mingw-w64-clang-aarch64-make'
      'mingw-w64-clang-aarch64-clang' 'mingw-w64-clang-aarch64-python'
      'mingw-w64-clang-aarch64-python-setuptools'
      'mingw-w64-clang-aarch64-cython' 'mingw-w64-clang-aarch64-autotools'
      'mingw-w64-clang-aarch64-ruby' 'mingw-w64-clang-aarch64-gettext'
      'mingw-w64-clang-aarch64-git' 'make' 'zsh' 'fish' 'mksh'
      'openssh' 'mingw-w64-clang-aarch64-python-setuptools-rust'
      'mingw-w64-clang-aarch64-rust' 'mingw-w64-clang-aarch64-go'
      'mingw-w64-clang-aarch64-lld' 'mingw-w64-clang-aarch64-libc++'
      'mingw-w64-clang-aarch64-llvm-tools' 'mingw-w64-clang-aarch64-flang'
      'mingw-w64-clang-aarch64-perl' 'mingw-w64-clang-aarch64-nodejs'
      'mingw-w64-clang-aarch64-openmp'"
    error: target not found: mingw-w64-clang-aarch64-openmp
    Error: The process 'C:\Windows\system32\cmd.exe' failed with exit code 1
```

The reason that this did not break earlier is that
`mingw-w64-llvm-openmp` was marked up as providing `mingw-w64-openmp`.
However, that changed in
https://github.com/msys2/MINGW-packages/commit/a51a89913330877d0323c879ac00742f5a3e7297#diff-1426b0d18c3dbdb1a0275b245cfc798091c71b4e6324653aef726b9be7ebd8bbL22-L24
which was most likely an accidental drive-by change.

Since that change, `mingw-w64-openmp` no longer resolves to any package.

Arguably it would be the correct thing to refer to that package by its
actual name, anyway, so let's address this error by doing that.
